### PR TITLE
ParallelGen.filter method also filters elements if bool(elm) == false

### DIFF
--- a/parallel/parallel_collections.py
+++ b/parallel/parallel_collections.py
@@ -62,7 +62,7 @@ class ParallelGen(object):
         
     def filter(self, pred):
         _filter = _Filter(pred)
-        return self.__class__(i for i in _map(_filter, self, ) if i)
+        return self.__class__((i for i in _map(_filter, self, ) if i is not None))
         
     def flatten(self):
         '''if the data source consists of several sequences, those will be chained in one'''


### PR DESCRIPTION
Hi gterzian,

 When using the filter method, I faced a problem that its result sequence sometimes missing an element(s) which is expected to be in.

This tiny example which reproduces the problem.

```
from parallel import parallel

def even(x):
    return x % 2 == 0

example = range(10)
result_par = parallel(example).filter(even)
result_std = filter(even, range(10))

print list(result_par) #  [2, 4, 6, 8]
print list(result_std) #  [0, 2, 4, 6, 8]

```

And another example.

```
from parallel import parallel

def flip(x):
    return not x

example = [True, True, False, False]
result_par = parallel(example).filter(flip)
result_std = filter(flip, example)

print list(result_par) #  []
print list(result_std) #  [False, False]
```

 It might be caused by if statement in a list comprehension at [ParallelGen.filter](https://github.com/gterzian/Python-Parallel-Collections/blob/master/parallel/parallel_collections.py#L65).

```
(i for i in _map(_filter, self, ) if i)
```

 I guess it intends to filter `None` element (predict from test.py), but it filters also `False`, `0`, `''`, etc.

 In my opinion, `None` shouldn't filtered because builtin filter method doesn't filter it, so people expect ParallelGen.filter also behaves like that. But it is not a problem but an issue so I don't care at this point.

This is a simple patch for this issue. I would be grateful if you could merge it.
