### PR TITLE
ParallelGen.filter() should adopt the same behavior with builtin-filter

### DIFF
--- a/parallel/parallel_collections.py
+++ b/parallel/parallel_collections.py
@@ -23,7 +23,10 @@ class _Filter(object):
     pickled and sent to other processes'''
     
     def __init__(self, predicate):
-        self.predicate = predicate
+        if predicate is None:
+            self.predicate = bool
+        else:
+            self.predicate = predicate
         
     def __call__(self, item):
         if self.predicate(item):

--- a/parallel/parallel_collections.py
+++ b/parallel/parallel_collections.py
@@ -27,7 +27,10 @@ class _Filter(object):
         
     def __call__(self, item):
         if self.predicate(item):
-            return item
+            return (True, item)
+        else:
+            return (False, None)
+
         
             
 class _Reducer(object):
@@ -62,7 +65,7 @@ class ParallelGen(object):
         
     def filter(self, pred):
         _filter = _Filter(pred)
-        return self.__class__((i for i in _map(_filter, self, ) if i is not None))
+        return self.__class__((i[1] for i in _map(_filter, self, ) if i[0]))
         
     def flatten(self):
         '''if the data source consists of several sequences, those will be chained in one'''

--- a/parallel/tests.py
+++ b/parallel/tests.py
@@ -42,6 +42,14 @@ class TestGen(unittest.TestCase):
         self.assertEquals(list(filtered), list([]))
         self.assertFalse(filtered is p)
 
+    def test_filter_with_none_as_func(self):
+        p = parallel((d for d in [False, True]))
+        self.assertTrue(p.__class__.__name__ == 'ParallelGen')
+        pred = None
+        filtered = p.filter(pred)
+        self.assertEquals(list(filtered), list([True]))
+        self.assertFalse(filtered is p)
+
     def test_flatmap(self):
         p = parallel((d for d in [range(10),range(10)]))
         self.assertTrue(p.__class__.__name__ == 'ParallelGen')
@@ -205,6 +213,9 @@ def double_dict(item):
         return [k, [i *2 for i in v]]
     except TypeError:
         return [k, v * 2]
+
+def ret_none(item):
+    return None
 
 if __name__ == '__main__':
     unittest.main()

--- a/parallel/tests.py
+++ b/parallel/tests.py
@@ -50,6 +50,14 @@ class TestGen(unittest.TestCase):
         self.assertEquals(list(filtered), list([True]))
         self.assertFalse(filtered is p)
 
+    def test_filter_for_none_false_elements(self):
+        p = parallel((d for d in [False, True, None]))
+        self.assertTrue(p.__class__.__name__ == 'ParallelGen')
+        pred = is_none_or_false
+        filtered = p.filter(pred)
+        self.assertEquals(list(filtered), list([False, None]))
+        self.assertFalse(filtered is p)
+
     def test_flatmap(self):
         p = parallel((d for d in [range(10),range(10)]))
         self.assertTrue(p.__class__.__name__ == 'ParallelGen')
@@ -216,6 +224,9 @@ def double_dict(item):
 
 def ret_none(item):
     return None
+
+def is_none_or_false(item):
+    return item is None or item is False
 
 if __name__ == '__main__':
     unittest.main()

--- a/parallel/tests.py
+++ b/parallel/tests.py
@@ -34,6 +34,14 @@ class TestGen(unittest.TestCase):
         self.assertEquals(list(filtered), list(['2','3']))
         self.assertFalse(filtered is p)
         
+    def test_filter_with_ret_none_func(self):
+        p = parallel((d for d in [True, False]))
+        self.assertTrue(p.__class__.__name__ == 'ParallelGen')
+        pred = ret_none
+        filtered = p.filter(pred)
+        self.assertEquals(list(filtered), list([]))
+        self.assertFalse(filtered is p)
+
     def test_flatmap(self):
         p = parallel((d for d in [range(10),range(10)]))
         self.assertTrue(p.__class__.__name__ == 'ParallelGen')


### PR DESCRIPTION
 As I mentioned in an earlier comment in the [Pull Request #2](https://github.com/gterzian/Python-Parallel-Collections/pull/2), I have a opinion that it should behaves same with Python builtin-filter. For clarify the "same behavior", I dived into the source code of filter_next() at the [bltinmodule.c](https://github.com/python/cpython/blob/master/Python/bltinmodule.c) in the [CPython](https://github.com/python/cpython/) repository.

 It seems to be interpreted as follows:
1. At first, function object which passed to filter method is None or bool(), it simply behaves filter which passed bool() method.
2. Otherwise, evaluate `bool(func(item))`. (The result is stored `ok` variable.).
3. If the value of `ok` stands for True, filter method returns `item`. Notice that it allows any Python object as item, including `None`.
4. If the value of `ok` stands for False, filter method return `null` - It means nothing (including `None`) is returned in Python world.

So back to the Python-Parallel-Collections, the differences between builtin filter and ParallelGen.filter() are only two:
- Whether it accepts None as evaluate function. (regarding 1.)

```
xs = [0, 1, 2, 3, 4]

filter(None, xs)   # returns [1, 2, 3, 4]

list(parallel(xs).filter(None))   # raises TypeError: 'NoneType' object 

```
- Whether it can be handle the None element in a sequence. (regarding 2.-4.)

```
def isNone(x):
    return x is None

xs = [0, 1, 2, None, 3, 4]

filter(isNone, xs)   # returns [None]

list(parallel(xs).filter(isNone))   # returns []

```

 I guess there are many approach to tackle this, but I propose a simple one of it which requires a small-difference against the current code.

 This is just a proposal, and moreover, I have no confidence in the naming of test functions (I'm not a native in English ;-<).
So if you feel it has a problem, feel free to request me to rewrite, or of course you could make another fix based on this modification if you'd like to.
